### PR TITLE
Enhance profile recommendations in retrieve profiles tutorial

### DIFF
--- a/scripts/11_retrieve_profiles.py
+++ b/scripts/11_retrieve_profiles.py
@@ -48,7 +48,7 @@ import polars as pl
 #
 # The index file below contains the **recommended profiles** for each subset:
 #
-# > **Note for future**: Project-specific custom profiles will be available through separate index files as needed.
+# > **Note for maintainers**: Maintainers may consider adding project-specific custom profiles through separate index files as needed.
 
 # %% Paths
 INDEX_FILE = "https://raw.githubusercontent.com/jump-cellpainting/datasets/v0.9.0/manifests/profile_index.csv"

--- a/scripts/11_retrieve_profiles.py
+++ b/scripts/11_retrieve_profiles.py
@@ -37,7 +37,7 @@ import polars as pl
 #
 # Each dataset is available in two processing versions:
 #
-# - **Standard** (e.g., `crispr`, `compound`, `orf`): Fully processed including batch correction steps. **Recommended for most analyses** as they provide better cross-dataset comparability and have undergone additional quality control.
+# - **Standard** (e.g., `crispr`, `compound`, `orf`): Fully processed including batch correction steps. **Recommended for most analyses** as they provide better cross-dataset comparability.
 #
 # - **Interpretable** (e.g., `crispr_interpretable`, `compound_interpretable`, `orf_interpretable`): Same initial processing but without batch correction transformations that modify the original feature space. Use these when you need to interpret individual morphological features or understand the biological meaning of specific measurements.
 #

--- a/scripts/11_retrieve_profiles.py
+++ b/scripts/11_retrieve_profiles.py
@@ -62,8 +62,6 @@ profile_index = pl.read_csv(INDEX_FILE)
 profile_index
 
 # %% [markdown]
-# ## Pipeline Information Encoded in File Names
-#
 # The processing pipeline applied to each dataset is encoded directly in the parquet file names.
 # The filename shows the sequence of processing steps that were applied, as defined in the
 # [JUMP profiling recipe documentation](https://github.com/broadinstitute/jump-profiling-recipe/blob/main/DOCUMENTATION.md).

--- a/scripts/11_retrieve_profiles.py
+++ b/scripts/11_retrieve_profiles.py
@@ -58,7 +58,35 @@ INDEX_FILE = "https://raw.githubusercontent.com/jump-cellpainting/datasets/v0.9.
 
 # %%
 profile_index = pl.read_csv(INDEX_FILE)
+
 profile_index
+
+# %% [markdown]
+# ## Pipeline Information Encoded in File Names
+#
+# The processing pipeline applied to each dataset is encoded directly in the parquet file names.
+# The filename shows the sequence of processing steps that were applied, as defined in the
+# [JUMP profiling recipe documentation](https://github.com/broadinstitute/jump-profiling-recipe/blob/main/DOCUMENTATION.md).
+#
+# Key pipeline steps include:
+# - `profiles`: Base profiles (initial data loading)
+# - `var`: Variance thresholding - dropping features with very low variability
+# - `mad`: Robust standardization - normalizing features so that controls on each plate have a mean of 0 and a standard deviation of 1
+# - `int`: Inverse Normal Transformation - transforming feature distributions to be more normally distributed
+# - `featselect`: Feature selection - various methods to select features including reducing features to the most diverse ones
+# - `harmony`: Harmony batch correction - removing technical variations between batches (this is the default)
+#
+# Let's extract and display the pipeline information from the file names:
+
+# %%
+pl.Config.set_fmt_str_lengths(200)
+display_df = profile_index.with_columns(
+    pl.col("url").str.extract(r"([^/]+)\.parquet$").alias("pipeline")
+).select("subset", "pipeline")
+display_df
+
+# %%
+pl.Config.set_fmt_str_lengths(50)
 
 # %% [markdown]
 # We do not need the 'etag' (used to check file integrity) column nor the 'interpretable' (i.e., before major modifications)

--- a/scripts/11_retrieve_profiles.py
+++ b/scripts/11_retrieve_profiles.py
@@ -43,8 +43,20 @@ import polars as pl
 #
 # All datasets are stored as Parquet files on AWS S3 and can be accessed directly via their URLs.
 # Snakemake workflows for producing these assembled profiles are available [here](https://github.com/broadinstitute/jump-profiling-recipe/).
-# The specific commit used to produce the profiles can be found in the folder path of each parquet file.
-# For example, `jump-profiling-recipe_2024_a917fa7` indicates commit `a917fa7` was used.
+#
+# To understand exactly how each profile was generated:
+# 1. Extract the commit from the URL path (e.g., `jump-profiling-recipe_2024_a917fa7` → commit `a917fa7`)
+# 2. Extract the pipeline string from the URL (the folder name after the subset, e.g., 
+#    `ORF/profiles_wellpos_cc_var_mad_outlier_featselect_sphering_harmony/`)
+# 3. In the repository at that commit, check the `inputs/` directory for configuration files:
+#    - Individual subsets (orf/crispr/compound) → check orf.json, crispr.json, compound.json
+#    - Combined "all" subsets → check pipeline_1.json, pipeline_2.json, pipeline_3.json
+# 4. Find the config file where the "pipeline" value matches your pipeline string
+#
+# Note: "_interpretable" versions are intermediate files from the same pipeline, captured before 
+# multivariate transformations like sphering or harmony. They use the same config but represent
+# an earlier step in the processing pipeline (e.g., `profiles_wellpos_cc_var_mad_outlier_featselect`
+# is the interpretable version before `_sphering_harmony` is applied).
 #
 # The index file below contains the **recommended profiles** for each subset:
 #

--- a/scripts/11_retrieve_profiles.py
+++ b/scripts/11_retrieve_profiles.py
@@ -39,7 +39,7 @@ import polars as pl
 #
 # - **Standard** (e.g., `crispr`, `compound`, `orf`): Fully processed including batch correction steps. **Recommended for most analyses** as they provide better cross-dataset comparability.
 #
-# - **Interpretable** (e.g., `crispr_interpretable`, `compound_interpretable`, `orf_interpretable`): Same initial processing but without batch correction transformations that modify the original feature space. Use these when you need to interpret individual morphological features or understand the biological meaning of specific measurements.
+# - **Interpretable** (e.g., `crispr_interpretable`, `compound_interpretable`, `orf_interpretable`): Same initial processing but without batch correction transformations that modify the original feature space. Use these when you need to interpret individual morphological features.
 #
 # All datasets are stored as Parquet files on AWS S3 and can be accessed directly via their URLs.
 # Snakemake workflows for producing these assembled profiles are available [here](https://github.com/broadinstitute/jump-profiling-recipe/).

--- a/scripts/11_retrieve_profiles.py
+++ b/scripts/11_retrieve_profiles.py
@@ -14,16 +14,11 @@
 #     name: python3
 # ---
 
-# %% [markdown]
-# This is a tutorial on how to access profiles from the [JUMP Cell Painting datasets](https://github.com/jump-cellpainting/datasets).
-# We will use polars to fetch the data frames lazily, with the help of `s3fs` and `pyarrow`.
-# We prefer lazy loading because the data can be too big to be handled in memory.
-
 # %% Imports
 import polars as pl
+import requests
 
 # %% [markdown]
-# ## JUMP Cell Painting Datasets & Recommendations
 #
 # The JUMP Cell Painting project provides several processed datasets for morphological profiling.
 # Choose the dataset that matches your perturbation type:
@@ -40,71 +35,66 @@ import polars as pl
 # - **Interpretable** (e.g., `crispr_interpretable`, `compound_interpretable`, `orf_interpretable`): Same initial processing but without batch correction transformations that modify the original feature space. Use these when you need to interpret individual morphological features.
 #
 # All datasets are stored as Parquet files on AWS S3 and can be accessed directly via their URLs.
-# Snakemake workflows for producing these assembled profiles are available [here](https://github.com/broadinstitute/jump-profiling-recipe/).
 #
-# To understand exactly how each profile was generated:
-# 1. Extract the commit from the URL path (e.g., `jump-profiling-recipe_2024_a917fa7` → commit `a917fa7`)
-# 2. Extract the pipeline string from the URL (the folder name after the subset, e.g.,
-#    `ORF/profiles_wellpos_cc_var_mad_outlier_featselect_sphering_harmony/`)
-# 3. In the repository at that commit, check the `inputs/` directory for configuration files:
-#    - Individual subsets (orf/crispr/compound) → check orf.json, crispr.json, compound.json
-#    - Combined "all" subsets → check pipeline_1.json, pipeline_2.json, pipeline_3.json
-# 4. Find the config file where the "pipeline" value matches your pipeline string
+# The index file below contains the **recommended profiles** for each subset. Each profile includes:
+# - Direct links to the processing recipe and configuration used
+# - ETags for data integrity verification
 #
-# Note: "_interpretable" versions are intermediate files from the same pipeline, captured before
-# multivariate transformations like sphering or harmony. They use the same config but represent
-# an earlier step in the processing pipeline (e.g., `profiles_wellpos_cc_var_mad_outlier_featselect`
-# is the interpretable version before `_sphering_harmony` is applied).
-#
-# The index file below contains the **recommended profiles** for each subset:
-#
-# > **Note for maintainers**: Maintainers may consider adding project-specific custom profiles through separate index files as needed.
+# For details on creating your own profile manifests, see the [manifest guide](https://github.com/broadinstitute/jump_hub/blob/main/howto/2_create_project_manifest.md).
 
 # %% Paths
-INDEX_FILE = "https://raw.githubusercontent.com/jump-cellpainting/datasets/v0.9.0/manifests/profile_index.csv"
+INDEX_FILE = "https://raw.githubusercontent.com/jump-cellpainting/datasets/main/manifests/profile_index.json"
 
 # %% [markdown]
-# We use the version-controlled CSV above to release the latest corrected profiles
+# We use the version-controlled manifest above to release the latest corrected profiles
 
 # %%
-profile_index = pl.read_csv(INDEX_FILE)
+# Load the JSON manifest
+response = requests.get(INDEX_FILE)
+profile_index = response.json()
 
-profile_index
+# Display the manifest data
+for dataset in profile_index:
+    print(f"- {dataset['subset']}: {dataset['url']}")
 
 # %% [markdown]
-# The processing pipeline applied to each dataset is encoded directly in the parquet file names.
-# The filename shows the sequence of processing steps that were applied, as defined in the
-# [JUMP profiling recipe documentation](https://github.com/broadinstitute/jump-profiling-recipe/blob/main/DOCUMENTATION.md).
+# Each profile in the manifest includes direct links to:
+# - **recipe_permalink**: The exact version of the processing code used
+# - **config_permalink**: The specific configuration file that defines the processing steps
 #
-# Key pipeline steps include:
-# - `profiles`: Base profiles (initial data loading)
-# - `var`: Variance thresholding - dropping features with very low variability
-# - `mad`: Robust standardization - normalizing features so that controls on each plate have a mean of 0 and a standard deviation of 1
-# - `int`: Inverse Normal Transformation - transforming feature distributions to be more normally distributed
-# - `featselect`: Feature selection - various methods to select features including reducing features to the most diverse ones
-# - `harmony`: Harmony batch correction - removing technical variations between batches (this is the default)
-#
-# Let's extract and display the pipeline information from the file names:
+# Let's display the key information from the manifest:
 
 # %%
-pl.Config.set_fmt_str_lengths(200)
-display_df = profile_index.with_columns(
-    pl.col("url").str.extract(r"([^/]+)\.parquet$").alias("pipeline")
-).select("subset", "pipeline")
+# Convert JSON to DataFrame for better display
+profile_df = pl.DataFrame(profile_index)
+
+# Show key information in a clean table
+display_df = profile_df.select(
+    [
+        "subset",
+        pl.col("url").str.extract(r"([^/]+)\.parquet$").alias("filename"),
+        pl.col("recipe_permalink")
+        .str.extract(r"tree/([^/]+)$")
+        .str.slice(0, 7)
+        .alias("recipe_version"),
+        pl.col("config_permalink").str.extract(r"([^/]+)\.json$").alias("config"),
+    ]
+)
 display_df
 
-# %%
-pl.Config.set_fmt_str_lengths(50)
-
 # %% [markdown]
-# We do not need the 'etag' (used to check file integrity) column nor the 'interpretable' (i.e., before major modifications)
+# Let inspect the standard profiles.
 
 # %%
-selected_profiles = profile_index.filter(
-    pl.col("subset").is_in(("crispr", "orf", "compound"))
-).select(pl.exclude("etag"))
-filepaths = dict(selected_profiles.iter_rows())
-print(filepaths)
+# Create dictionary of subset -> url for the standard profiles only
+filepaths = {
+    dataset["subset"]: dataset["url"]
+    for dataset in profile_index
+    if dataset["subset"] in ("crispr", "orf", "compound")
+}
+print("Selected profiles:")
+for subset, url in filepaths.items():
+    print(f"  {subset}: {url.split('/')[-1]}")
 
 # %% [markdown]
 # We will lazy-load the dataframes and print the number of rows and columns

--- a/scripts/11_retrieve_profiles.py
+++ b/scripts/11_retrieve_profiles.py
@@ -33,8 +33,6 @@ import polars as pl
 # - **`compound`**: Chemical compound perturbations
 # - **`all`**: Combined dataset containing all perturbation types (use for cross-modality comparisons)
 #
-# ### Standard vs Interpretable Versions
-#
 # Each dataset is available in two processing versions:
 #
 # - **Standard** (e.g., `crispr`, `compound`, `orf`): Fully processed including batch correction steps. **Recommended for most analyses** as they provide better cross-dataset comparability.
@@ -46,14 +44,14 @@ import polars as pl
 #
 # To understand exactly how each profile was generated:
 # 1. Extract the commit from the URL path (e.g., `jump-profiling-recipe_2024_a917fa7` → commit `a917fa7`)
-# 2. Extract the pipeline string from the URL (the folder name after the subset, e.g., 
+# 2. Extract the pipeline string from the URL (the folder name after the subset, e.g.,
 #    `ORF/profiles_wellpos_cc_var_mad_outlier_featselect_sphering_harmony/`)
 # 3. In the repository at that commit, check the `inputs/` directory for configuration files:
 #    - Individual subsets (orf/crispr/compound) → check orf.json, crispr.json, compound.json
 #    - Combined "all" subsets → check pipeline_1.json, pipeline_2.json, pipeline_3.json
 # 4. Find the config file where the "pipeline" value matches your pipeline string
 #
-# Note: "_interpretable" versions are intermediate files from the same pipeline, captured before 
+# Note: "_interpretable" versions are intermediate files from the same pipeline, captured before
 # multivariate transformations like sphering or harmony. They use the same config but represent
 # an earlier step in the processing pipeline (e.g., `profiles_wellpos_cc_var_mad_outlier_featselect`
 # is the interpretable version before `_sphering_harmony` is applied).

--- a/scripts/11_retrieve_profiles.py
+++ b/scripts/11_retrieve_profiles.py
@@ -23,23 +23,32 @@
 import polars as pl
 
 # %% [markdown]
-# The JUMP Cell Painting project provides several processed datasets for morphological profiling:
+# ## JUMP Cell Painting Datasets & Recommendations
+#
+# The JUMP Cell Painting project provides several processed datasets for morphological profiling.
+# Choose the dataset that matches your perturbation type:
 #
 # - **`crispr`**: CRISPR knockout genetic perturbations
 # - **`orf`**: Open Reading Frame (ORF) overexpression perturbations
 # - **`compound`**: Chemical compound perturbations
-# - **`all`**: Combined dataset containing all perturbation types
+# - **`all`**: Combined dataset containing all perturbation types (use for cross-modality comparisons)
 #
-# Each dataset is available in two versions:
+# ### Standard vs Interpretable Versions
 #
-# - **Standard**: Fully processed including batch correction
-# - **Interpretable**: Same processing but without batch correction steps (which involve transformations that lose the original feature space)
+# Each dataset is available in two processing versions:
+#
+# - **Standard** (e.g., `crispr`, `compound`, `orf`): Fully processed including batch correction steps. **Recommended for most analyses** as they provide better cross-dataset comparability and have undergone additional quality control.
+#
+# - **Interpretable** (e.g., `crispr_interpretable`, `compound_interpretable`, `orf_interpretable`): Same initial processing but without batch correction transformations that modify the original feature space. Use these when you need to interpret individual morphological features or understand the biological meaning of specific measurements.
 #
 # All datasets are stored as Parquet files on AWS S3 and can be accessed directly via their URLs.
 # Snakemake workflows for producing these assembled profiles are available [here](https://github.com/broadinstitute/jump-profiling-recipe/).
 # The specific commit used to produce the profiles can be found in the folder path of each parquet file.
 # For example, `jump-profiling-recipe_2024_a917fa7` indicates commit `a917fa7` was used.
-# The index file below contains the exact locations and metadata for each dataset:
+#
+# The index file below contains the **recommended profiles** for each subset:
+#
+# > **Note for future**: Project-specific custom profiles will be available through separate index files as needed.
 
 # %% Paths
 INDEX_FILE = "https://raw.githubusercontent.com/jump-cellpainting/datasets/v0.9.0/manifests/profile_index.csv"
@@ -49,7 +58,7 @@ INDEX_FILE = "https://raw.githubusercontent.com/jump-cellpainting/datasets/v0.9.
 
 # %%
 profile_index = pl.read_csv(INDEX_FILE)
-profile_index.head()
+profile_index
 
 # %% [markdown]
 # We do not need the 'etag' (used to check file integrity) column nor the 'interpretable' (i.e., before major modifications)


### PR DESCRIPTION
## Summary
- Add explicit guidance on which dataset to use for each perturbation type
- Expand explanations of standard vs interpretable profile versions with examples
- Emphasize that standard profiles are recommended for most analyses
- Clarify that the CSV index contains recommended profiles
- Show complete profile index for better visibility

## Test plan
- [x] Review tutorial content for clarity and accuracy
- [x] Test notebook execution to ensure changes don't break functionality

🤖 Generated with [Claude Code](https://claude.ai/code)