### PR TITLE
docs: refer to new manifest json #102

### DIFF
--- a/explanations/FAQ.md
+++ b/explanations/FAQ.md
@@ -34,9 +34,9 @@ You can find all positive and negative controls for JUMP-ORF, -CRISPR, and -comp
 For the compounds dataset the only negative control is 'JCP2022_033924' (DMSO). 
 Most chemical compound plates contain 16 negative control wells, while some have as many as 28 wells. In the ORF dataset, replicates are positioned in wells O23, O24, P23 and P24. The remaining wells contain ORF treatments, with a single replicate of each per plate map and with five replicate plates produced per plate map ([private link](https://github.com/jump-cellpainting/megamap/issues/8#issuecomment-1413606031) | [html](https://zenodo.org/records/15699904/files/megamap_no_replicates.html?download=1)).
 
-### Which pipelines produced the final datasets?
+### Which pipelines produced the latest datasets?
 
-Details on the pipelines at each step can be found on [this](../reference/computational_pipelines.md) page.
+The [profiles_index.json](https://github.com/jump-cellpainting/datasets/blob/main/manifests/profile_index.json) file contains links to the specific version of the [jump profiling recipe](https://github.com/broadinstitute/jump-profiling-recipe) used and its configuration.
 
 ### Do we expect one gene’s JCP ID (JUMP Cell Painting ID) to be associated with multiple targets?
 

--- a/reference/computational_pipelines.md
+++ b/reference/computational_pipelines.md
@@ -3,8 +3,3 @@
 ## Image Processing Pipeline
 
 CellProfiler pipelines for segmentation and feature extraction as well as QC and illumination correction can be found on Github [here](https://github.com/broadinstitute/imaging-platform-pipelines/tree/master/JUMP_production).
-
-## Profile Generation
-
-The complete workflow for processing CellProfiler features (including annotation, normalization, and feature selection) is documented in the [`jump-profiling-recipe`](https://github.com/broadinstitute/jump-profiling-recipe) repository. Version [v0.1.0](https://github.com/broadinstitute/jump-profiling-recipe/releases/tag/v0.1.0) was used to generate the processed profiles available in the JUMP datasets.
-


### PR DESCRIPTION
Replace the original "final profiles" docs with links to the new profile_index.json, the profiling recipe urls and the configs. The one thing leftover is what to do with the link to the jump-production pipeline still in [computational_pipelines.md](https://github.com/broadinstitute/jump_hub/blob/2e5833a0ffeee3cbd9d360b8dddefee91ce2c82f/reference/computational_pipelines.md#L1). Is that still relevant?