### PR TITLE
Mirror Zenodo JUMP_rr datasets to CPG S3 (re #124)

### DIFF
--- a/.github/workflows/mirror_zenodo.yml
+++ b/.github/workflows/mirror_zenodo.yml
@@ -4,7 +4,9 @@ name: Mirror Zenodo to CPG
 #
 # Triggers:
 #   - Manual (workflow_dispatch) - safe to run any time; idempotent.
-#   - Scheduled cron (commented out by default).
+#   - Scheduled cron - daily 06:00 UTC. Idempotent runs with no Zenodo change
+#     are seconds; a real new-version run is hours but well under the 360-min
+#     timeout. The mirror is safe to re-trigger at any cadence.
 #
 # Credentials:
 #   AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are the static IAM access keys
@@ -26,8 +28,8 @@ on:
         description: "Set to 1 to preview without uploading"
         required: false
         default: "0"
-  # schedule:
-  #   - cron: "0 6 * * *"  # daily 06:00 UTC
+  schedule:
+    - cron: "0 6 * * *"  # daily 06:00 UTC
 
 jobs:
   mirror:

--- a/.github/workflows/mirror_zenodo.yml
+++ b/.github/workflows/mirror_zenodo.yml
@@ -40,5 +40,8 @@ jobs:
         env:
           CONCEPT_ID: ${{ inputs.concept_id || '10408587' }}
           DRY_RUN: ${{ inputs.dry_run || '0' }}
-          AWS_PROFILE_NAME: default
+          # configure-aws-credentials sets env-var credentials, not a named
+          # profile in ~/.aws. Empty AWS_PROFILE_NAME tells the script to
+          # call `aws` without `--profile`.
+          AWS_PROFILE_NAME: ""
         run: ./tools/mirror_zenodo_to_cpg.sh

--- a/.github/workflows/mirror_zenodo.yml
+++ b/.github/workflows/mirror_zenodo.yml
@@ -1,0 +1,44 @@
+name: Mirror Zenodo to CPG
+
+# Runs tools/mirror_zenodo_to_cpg.sh against the JUMP_rr Zenodo concept.
+#
+# Triggers:
+#   - Manual (workflow_dispatch) - safe to run any time; idempotent.
+#   - Scheduled cron (commented out by default) - enable once AWS_ACCESS_KEY_ID
+#     and AWS_SECRET_ACCESS_KEY repository secrets are wired to a CPG-write
+#     credential. Without those secrets the job will fail.
+
+on:
+  workflow_dispatch:
+    inputs:
+      concept_id:
+        description: "Zenodo concept ID to mirror"
+        required: false
+        default: "10408587"
+      dry_run:
+        description: "Set to 1 to preview without uploading"
+        required: false
+        default: "0"
+  # schedule:
+  #   - cron: "0 6 * * *"  # daily 06:00 UTC
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Run mirror script
+        env:
+          CONCEPT_ID: ${{ inputs.concept_id || '10408587' }}
+          DRY_RUN: ${{ inputs.dry_run || '0' }}
+          AWS_PROFILE_NAME: default
+        run: ./tools/mirror_zenodo_to_cpg.sh

--- a/.github/workflows/mirror_zenodo.yml
+++ b/.github/workflows/mirror_zenodo.yml
@@ -4,9 +4,16 @@ name: Mirror Zenodo to CPG
 #
 # Triggers:
 #   - Manual (workflow_dispatch) - safe to run any time; idempotent.
-#   - Scheduled cron (commented out by default) - enable once AWS_ACCESS_KEY_ID
-#     and AWS_SECRET_ACCESS_KEY repository secrets are wired to a CPG-write
-#     credential. Without those secrets the job will fail.
+#   - Scheduled cron (commented out by default).
+#
+# Credentials:
+#   AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are the static IAM access keys
+#   provisioned by cellpainting-gallery-infra (CDK ManagedPrefixGrant). Those
+#   keys only carry s3:GetDataAccess; this workflow uses them to mint
+#   temporary, prefix-scoped S3 credentials via s3control get-data-access
+#   (12h lifetime, far longer than the worst-case mirror) and runs the mirror
+#   script under those temp creds. The mirror script itself is unchanged --
+#   it sees standard AWS_* env vars and is unaware of Access Grants.
 
 on:
   workflow_dispatch:
@@ -35,6 +42,30 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
+
+      - name: Mint S3 Access Grants temporary credentials
+        env:
+          CPG_ACCOUNT_ID: "309624411020"
+          CPG_BUCKET: cellpainting-gallery
+          CPG_PREFIX: cpg0042-chandrasekaran-jump/source_all/workspace/publication_data/jump_rr
+        run: |
+          set -euo pipefail
+          creds=$(aws s3control get-data-access \
+            --account-id "$CPG_ACCOUNT_ID" \
+            --target "s3://${CPG_BUCKET}/${CPG_PREFIX}/*" \
+            --permission READWRITE \
+            --duration-seconds 43200 \
+            --region us-east-1 \
+            --output json)
+          for k in AccessKeyId SecretAccessKey SessionToken; do
+            v=$(jq -r ".Credentials.$k" <<< "$creds")
+            echo "::add-mask::$v"
+          done
+          {
+            echo "AWS_ACCESS_KEY_ID=$(jq -r .Credentials.AccessKeyId   <<< "$creds")"
+            echo "AWS_SECRET_ACCESS_KEY=$(jq -r .Credentials.SecretAccessKey <<< "$creds")"
+            echo "AWS_SESSION_TOKEN=$(jq -r .Credentials.SessionToken <<< "$creds")"
+          } >> "$GITHUB_ENV"
 
       - name: Run mirror script
         env:

--- a/howto/maintenance/2_mirror_zenodo_to_cpg.md
+++ b/howto/maintenance/2_mirror_zenodo_to_cpg.md
@@ -44,6 +44,27 @@ CONCEPT_ID=12345678 ./tools/mirror_zenodo_to_cpg.sh
 AWS_PROFILE_NAME=my-profile ./tools/mirror_zenodo_to_cpg.sh
 ```
 
+## Credential paths
+
+There are two ways the script can be run, with different credential mechanics:
+
+1. **Direct S3 access (local maintainer use).** A profile like `cpg` mapped to an IAM user that has direct `s3:PutObject` / `s3:GetObject` on the bucket. The script's defaults (`AWS_PROFILE_NAME=cpg`) work as-is. This is the path most contributors will already have via the [Cell Painting Gallery contribution guidelines](https://broadinstitute.github.io/cellpainting-gallery/contributing_to_cpg.html).
+
+2. **S3 Access Grants (CI / infra-issued credentials).** The IAM keys that [`cellpainting-gallery-infra`](https://github.com/broadinstitute/cellpainting-gallery-infra) provisions for a prefix carry only `s3:GetDataAccess`, not direct S3 actions. To use them you must first mint temporary, prefix-scoped credentials and export them as standard AWS env vars:
+
+   ```bash
+   creds=$(aws s3control get-data-access \
+     --account-id 309624411020 \
+     --target "s3://cellpainting-gallery/cpg0042-chandrasekaran-jump/source_all/workspace/publication_data/jump_rr/*" \
+     --permission READWRITE --duration-seconds 43200 --region us-east-1 --output json)
+   export AWS_ACCESS_KEY_ID=$(jq -r .Credentials.AccessKeyId    <<< "$creds")
+   export AWS_SECRET_ACCESS_KEY=$(jq -r .Credentials.SecretAccessKey <<< "$creds")
+   export AWS_SESSION_TOKEN=$(jq -r .Credentials.SessionToken   <<< "$creds")
+   AWS_PROFILE_NAME="" ./tools/mirror_zenodo_to_cpg.sh
+   ```
+
+   The temp credentials live for up to 12 hours, comfortably more than the worst-case mirror runtime. The GitHub Actions workflow (`.github/workflows/mirror_zenodo.yml`) does exactly this in a dedicated step before invoking the script, so the script itself stays Access-Grants-unaware.
+
 ## How idempotency works
 
 The script stores the Zenodo MD5 checksum as S3 user metadata on each uploaded object under the key `zenodo-md5`. On subsequent runs, the script checks the existing object's `zenodo-md5` against the Zenodo file's MD5:

--- a/howto/maintenance/2_mirror_zenodo_to_cpg.md
+++ b/howto/maintenance/2_mirror_zenodo_to_cpg.md
@@ -1,0 +1,68 @@
+# Mirroring Zenodo Datasets to Cell Painting Gallery
+
+The JUMP_rr feature, match, gallery, and significance tables are published to Zenodo with a stable concept DOI. To keep load times responsive (especially for browser-based tools like Datasette Lite and ggsql-wasm), each Zenodo release is mirrored onto the Cell Painting Gallery (CPG) S3 bucket using `tools/mirror_zenodo_to_cpg.sh`.
+
+## What the script does
+
+For every file in the latest version of a Zenodo concept, the script writes the file to two locations on CPG:
+
+```
+s3://cellpainting-gallery/cpg0042-chandrasekaran-jump/source_all/workspace/publication_data/jump_rr/
+    <record_id>/<file>      # immutable per-version copy
+    latest/<file>           # mutable pointer to the most recent version
+```
+
+`<record_id>` is the Zenodo record ID for that specific version (e.g. `19835081`). Each new Zenodo version gets a new record ID and a new `<record_id>/` directory on CPG; the previous one is left untouched. The `latest/` directory is always overwritten with the newest version, so `broad.io/*` short links can target `latest/` once and never need to be updated again.
+
+Zenodo remains the canonical, citable archive. CPG is the runtime origin that browser tools fetch from.
+
+## When to run it
+
+Run the script after a new version of the Zenodo record has been published. It can also be run on a schedule (e.g. daily cron) - if Zenodo has not changed, the script does not re-upload anything.
+
+## Requirements
+
+- AWS CLI configured with a profile that has write access to the `cellpainting-gallery` bucket. By default the script uses a profile named `cpg`. See the [Cell Painting Gallery contribution guidelines](https://broadinstitute.github.io/cellpainting-gallery/contributing_to_cpg.html).
+- `curl` and `jq` on `PATH`.
+
+## Usage
+
+```bash
+# Mirror the default Zenodo concept (10408587 - JUMP_rr processed datasets)
+./tools/mirror_zenodo_to_cpg.sh
+
+# Preview without uploading
+DRY_RUN=1 ./tools/mirror_zenodo_to_cpg.sh
+
+# Mirror a single file (useful for testing)
+ONLY_FILE=crispr_gallery.parquet ./tools/mirror_zenodo_to_cpg.sh
+
+# Mirror a different Zenodo concept
+CONCEPT_ID=12345678 ./tools/mirror_zenodo_to_cpg.sh
+
+# Use a different AWS profile
+AWS_PROFILE_NAME=my-profile ./tools/mirror_zenodo_to_cpg.sh
+```
+
+## How idempotency works
+
+The script stores the Zenodo MD5 checksum as S3 user metadata on each uploaded object under the key `zenodo-md5`. On subsequent runs, the script checks the existing object's `zenodo-md5` against the Zenodo file's MD5:
+
+- Match: skip the upload. The version copy is already correct.
+- No match (or object missing): stream the file from Zenodo to S3.
+
+The `latest/` copy is always refreshed via a server-side S3-to-S3 copy from the version directory. This is cheap and ensures `latest/` self-heals if it ever drifts.
+
+## Streaming behavior
+
+The script pipes `curl` directly into `aws s3 cp -`, so the file is never written to local disk. This matters for the larger files in the JUMP_rr record (the compound cosine-similarity table is around 49 GB), which would not fit on a typical CI runner's local disk.
+
+## Why a `latest/` directory and not symlinks
+
+S3 has no native symlink mechanism. The two-directory pattern (immutable `<record_id>/` plus mutable `latest/`) is the conventional workaround: callers can either pin to a specific version for reproducibility or follow `latest/` for the current data. Updates to `latest/` are atomic at the file level.
+
+## What's not covered by this script
+
+- Publishing to Zenodo. The Zenodo release is cut by whoever owns the JUMP_rr generation pipeline. This script only mirrors what is already on Zenodo.
+- Updating `broad.io/*` short links. If `latest/` is the persistent target, no updates are needed for ongoing releases. If a short link still references a Zenodo URL, that's a one-time repointing that lives outside this script.
+- Other artifacts on CPG (such as the v0.13 metadata DuckDB at `publication_data/datasets/v0.13/`) that are not sourced from this Zenodo concept.

--- a/howto/maintenance/2_mirror_zenodo_to_cpg.md
+++ b/howto/maintenance/2_mirror_zenodo_to_cpg.md
@@ -8,11 +8,13 @@ For every file in the latest version of a Zenodo concept, the script writes the 
 
 ```
 s3://cellpainting-gallery/cpg0042-chandrasekaran-jump/source_all/workspace/publication_data/jump_rr/
-    <record_id>/<file>      # immutable per-version copy
-    latest/<file>           # mutable pointer to the most recent version
+    <record_id>/<file>/content      # immutable per-version copy
+    latest/<file>/content           # mutable pointer to the most recent version
 ```
 
 `<record_id>` is the Zenodo record ID for that specific version (e.g. `19835081`). Each new Zenodo version gets a new record ID and a new `<record_id>/` directory on CPG; the previous one is left untouched. The `latest/` directory is always overwritten with the newest version, so `broad.io/*` short links can target `latest/` once and never need to be updated again.
+
+The trailing `/content` suffix mirrors Zenodo's own download URL structure (`https://zenodo.org/api/records/<id>/files/<file>/content`). Datasette-Lite derives its table name from the URL's last path segment; preserving `content` as the last segment on both backends keeps the [JUMP_rr metadata JSONs](https://github.com/broadinstitute/monorepo/tree/main/libs/jump_rr/metadata) (which key descriptions under `databases.data.tables.content`) valid against the CPG-served parquet.
 
 Zenodo remains the canonical, citable archive. CPG is the runtime origin that browser tools fetch from.
 

--- a/howto/maintenance/2_mirror_zenodo_to_cpg.md
+++ b/howto/maintenance/2_mirror_zenodo_to_cpg.md
@@ -16,7 +16,7 @@ s3://cellpainting-gallery/cpg0042-chandrasekaran-jump/source_all/workspace/publi
 
 The trailing `/content` suffix mirrors Zenodo's own download URL structure (`https://zenodo.org/api/records/<id>/files/<file>/content`). Datasette-Lite derives its table name from the URL's last path segment; preserving `content` as the last segment on both backends keeps the [JUMP_rr metadata JSONs](https://github.com/broadinstitute/monorepo/tree/main/libs/jump_rr/metadata) (which key descriptions under `databases.data.tables.content`) valid against the CPG-served parquet.
 
-Zenodo remains the canonical, citable archive. CPG is the runtime origin that browser tools fetch from.
+Zenodo remains the canonical, citable archive. CPG is the storage origin; in practice browser tools fetch through the CloudFront edge cache that sits in front of the JUMP_rr subtree (`d3dw4c1b79pj57.cloudfront.net`, provisioned by [`cellpainting-gallery-infra`](https://github.com/broadinstitute/cellpainting-gallery-infra)'s `JumpRrCdnStack`). The CDN's 1h cache TTL means a daily-cron mirror update to `latest/` is visible to consumers within an hour without any manual cache invalidation. The mirror script itself writes only to S3 — it doesn't need to know about the CDN.
 
 ## When to run it
 

--- a/tools/mirror_zenodo_to_cpg.sh
+++ b/tools/mirror_zenodo_to_cpg.sh
@@ -20,9 +20,18 @@ set -euo pipefail
 CONCEPT_ID="${CONCEPT_ID:-10408587}"
 S3_BUCKET="${S3_BUCKET:-cellpainting-gallery}"
 S3_PREFIX="${S3_PREFIX:-cpg0042-chandrasekaran-jump/source_all/workspace/publication_data/jump_rr}"
-AWS_PROFILE_NAME="${AWS_PROFILE_NAME:-cpg}"
+AWS_PROFILE_NAME="${AWS_PROFILE_NAME-cpg}"
 DRY_RUN="${DRY_RUN:-0}"
 ONLY_FILE="${ONLY_FILE:-}"
+
+# Build the optional `--profile <name>` arg only when AWS_PROFILE_NAME is set
+# and non-empty. In GitHub Actions, aws-actions/configure-aws-credentials
+# exports credentials as environment variables and does not create a
+# `default` profile, so passing `--profile default` would fail.
+profile_args=()
+if [ -n "${AWS_PROFILE_NAME}" ]; then
+    profile_args=(--profile "$AWS_PROFILE_NAME")
+fi
 
 log() { printf '%s %s\n' "[$(date -u +%H:%M:%SZ)]" "$*"; }
 
@@ -62,7 +71,7 @@ while IFS=$'\t' read -r name url size md5; do
 
     existing_md5=$(aws s3api head-object \
         --bucket "$S3_BUCKET" --key "$version_key" \
-        --profile "$AWS_PROFILE_NAME" 2>/dev/null \
+        "${profile_args[@]}" 2>/dev/null \
         | jq -r '.Metadata."zenodo-md5" // empty' || true)
 
     if [ "$existing_md5" = "$md5" ]; then
@@ -71,14 +80,14 @@ while IFS=$'\t' read -r name url size md5; do
     else
         log "  upload: streaming Zenodo -> $version_uri"
         if [ "$DRY_RUN" = "1" ]; then
-            printf '  DRY-RUN: curl -fsSL %s | aws s3 cp - %s --expected-size %s --metadata zenodo-md5=%s,zenodo-record-id=%s --profile %s\n' \
-                "$url" "$version_uri" "$size" "$md5" "$record_id" "$AWS_PROFILE_NAME"
+            printf '  DRY-RUN: curl -fsSL %s | aws s3 cp - %s --expected-size %s --metadata zenodo-md5=%s,zenodo-record-id=%s %s\n' \
+                "$url" "$version_uri" "$size" "$md5" "$record_id" "${profile_args[*]}"
         else
             curl -fsSL "$url" \
                 | aws s3 cp - "$version_uri" \
                     --expected-size "$size" \
                     --metadata "zenodo-md5=${md5},zenodo-record-id=${record_id}" \
-                    --profile "$AWS_PROFILE_NAME"
+                    "${profile_args[@]}"
         fi
         uploaded=$((uploaded + 1))
     fi
@@ -87,7 +96,7 @@ while IFS=$'\t' read -r name url size md5; do
     run_aws s3 cp "$version_uri" "$latest_uri" \
         --metadata-directive REPLACE \
         --metadata "zenodo-md5=${md5},zenodo-record-id=${record_id}" \
-        --profile "$AWS_PROFILE_NAME" \
+        "${profile_args[@]}" \
         --only-show-errors
     synced=$((synced + 1))
 done < <(printf '%s' "$record_json" \

--- a/tools/mirror_zenodo_to_cpg.sh
+++ b/tools/mirror_zenodo_to_cpg.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Mirror a Zenodo record onto the Cell Painting Gallery S3 bucket.
+#
+# Streams each file from Zenodo straight to S3 (no large local downloads),
+# writing to two paths per file:
+#   - <S3_PREFIX>/<record_id>/<file>   immutable per-version copy
+#   - <S3_PREFIX>/latest/<file>        mutable pointer to the most recent version
+#
+# Idempotent: stores the Zenodo MD5 as S3 user metadata `zenodo-md5` and skips
+# uploads when the existing object already carries the same checksum.
+#
+# Usage:
+#   ./mirror_zenodo_to_cpg.sh                  # mirror default record
+#   DRY_RUN=1 ./mirror_zenodo_to_cpg.sh        # print actions without uploading
+#   CONCEPT_ID=10408587 ./mirror_zenodo_to_cpg.sh
+#   ONLY_FILE=crispr_gallery.parquet ./mirror_zenodo_to_cpg.sh
+
+set -euo pipefail
+
+CONCEPT_ID="${CONCEPT_ID:-10408587}"
+S3_BUCKET="${S3_BUCKET:-cellpainting-gallery}"
+S3_PREFIX="${S3_PREFIX:-cpg0042-chandrasekaran-jump/source_all/workspace/publication_data/jump_rr}"
+AWS_PROFILE_NAME="${AWS_PROFILE_NAME:-cpg}"
+DRY_RUN="${DRY_RUN:-0}"
+ONLY_FILE="${ONLY_FILE:-}"
+
+log() { printf '%s %s\n' "[$(date -u +%H:%M:%SZ)]" "$*"; }
+
+run_aws() {
+    if [ "$DRY_RUN" = "1" ]; then
+        printf '  DRY-RUN: aws %s\n' "$*"
+    else
+        aws "$@"
+    fi
+}
+
+log "Resolving latest version of Zenodo concept $CONCEPT_ID"
+record_json=$(curl -fsSL "https://zenodo.org/api/records/${CONCEPT_ID}/versions/latest")
+record_id=$(printf '%s' "$record_json" | jq -r '.id')
+record_doi=$(printf '%s' "$record_json" | jq -r '.doi')
+pub_date=$(printf '%s' "$record_json" | jq -r '.metadata.publication_date')
+file_count=$(printf '%s' "$record_json" | jq '.files | length')
+
+log "Latest record: $record_id (doi $record_doi, published $pub_date, $file_count files)"
+log "Target prefix: s3://${S3_BUCKET}/${S3_PREFIX}/{${record_id},latest}/"
+
+skipped=0
+uploaded=0
+synced=0
+
+while IFS=$'\t' read -r name url size md5; do
+    if [ -n "$ONLY_FILE" ] && [ "$name" != "$ONLY_FILE" ]; then
+        continue
+    fi
+
+    version_key="${S3_PREFIX}/${record_id}/${name}"
+    latest_key="${S3_PREFIX}/latest/${name}"
+    version_uri="s3://${S3_BUCKET}/${version_key}"
+    latest_uri="s3://${S3_BUCKET}/${latest_key}"
+
+    log "FILE $name (size=${size}, md5=${md5})"
+
+    existing_md5=$(aws s3api head-object \
+        --bucket "$S3_BUCKET" --key "$version_key" \
+        --profile "$AWS_PROFILE_NAME" 2>/dev/null \
+        | jq -r '.Metadata."zenodo-md5" // empty' || true)
+
+    if [ "$existing_md5" = "$md5" ]; then
+        log "  skip upload: $version_uri already has matching zenodo-md5"
+        skipped=$((skipped + 1))
+    else
+        log "  upload: streaming Zenodo -> $version_uri"
+        if [ "$DRY_RUN" = "1" ]; then
+            printf '  DRY-RUN: curl -fsSL %s | aws s3 cp - %s --expected-size %s --metadata zenodo-md5=%s,zenodo-record-id=%s --profile %s\n' \
+                "$url" "$version_uri" "$size" "$md5" "$record_id" "$AWS_PROFILE_NAME"
+        else
+            curl -fsSL "$url" \
+                | aws s3 cp - "$version_uri" \
+                    --expected-size "$size" \
+                    --metadata "zenodo-md5=${md5},zenodo-record-id=${record_id}" \
+                    --profile "$AWS_PROFILE_NAME"
+        fi
+        uploaded=$((uploaded + 1))
+    fi
+
+    log "  sync: $version_uri -> $latest_uri"
+    run_aws s3 cp "$version_uri" "$latest_uri" \
+        --metadata-directive REPLACE \
+        --metadata "zenodo-md5=${md5},zenodo-record-id=${record_id}" \
+        --profile "$AWS_PROFILE_NAME" \
+        --only-show-errors
+    synced=$((synced + 1))
+done < <(printf '%s' "$record_json" \
+    | jq -r '.files[] | [.key, .links.self, (.size|tostring), (.checksum|sub("^md5:"; ""))] | @tsv')
+
+log "Done. uploaded=$uploaded skipped=$skipped synced=$synced"

--- a/tools/mirror_zenodo_to_cpg.sh
+++ b/tools/mirror_zenodo_to_cpg.sh
@@ -3,8 +3,16 @@
 #
 # Streams each file from Zenodo straight to S3 (no large local downloads),
 # writing to two paths per file:
-#   - <S3_PREFIX>/<record_id>/<file>   immutable per-version copy
-#   - <S3_PREFIX>/latest/<file>        mutable pointer to the most recent version
+#   - <S3_PREFIX>/<record_id>/<file>/content   immutable per-version copy
+#   - <S3_PREFIX>/latest/<file>/content        mutable pointer to the most recent
+#
+# The trailing /content suffix mirrors Zenodo's own download URL structure
+# (https://zenodo.org/api/records/<id>/files/<file>/content) so that
+# Datasette-Lite, which derives its table name from the URL's last path
+# segment, registers the parquet under the same name on both backends. This
+# lets broad.io/* short links be repointed by swapping only the parquet=
+# URL parameter -- metadata table keys (`databases.data.tables.content` in
+# the jump_rr metadata JSONs) remain valid.
 #
 # Idempotent: stores the Zenodo MD5 as S3 user metadata `zenodo-md5` and skips
 # uploads when the existing object already carries the same checksum.
@@ -62,8 +70,8 @@ while IFS=$'\t' read -r name url size md5; do
         continue
     fi
 
-    version_key="${S3_PREFIX}/${record_id}/${name}"
-    latest_key="${S3_PREFIX}/latest/${name}"
+    version_key="${S3_PREFIX}/${record_id}/${name}/content"
+    latest_key="${S3_PREFIX}/latest/${name}/content"
     version_uri="s3://${S3_BUCKET}/${version_key}"
     latest_uri="s3://${S3_BUCKET}/${latest_key}"
 


### PR DESCRIPTION
## Summary

Closes the data-hosting half of #124 by mirroring the JUMP_rr Zenodo datasets onto the Cell Painting Gallery S3 bucket, which serves Datasette Lite and ggsql-wasm consumers several times faster than Zenodo. Implements the counter-proposal @afermg laid out in [#124 (comment)](https://github.com/broadinstitute/jump_hub/issues/124#issuecomment-4338594497): a single mirror script, no jump_hub-side manifest layer, no SNAPPY/ZSTD split.

- `tools/mirror_zenodo_to_cpg.sh` - bash script that streams each file in a Zenodo concept's latest version to S3, writing both an immutable `<record_id>/` directory and a mutable `latest/` directory.
- `howto/maintenance/2_mirror_zenodo_to_cpg.md` - operator-facing doc.
- `.github/workflows/mirror_zenodo.yml` - `workflow_dispatch` + daily 06:00 UTC cron. Static IAM keys provisioned by [`cellpainting-gallery-infra`](https://github.com/broadinstitute/cellpainting-gallery-infra) live in repo secrets and only carry `s3:GetDataAccess`; the workflow mints temporary, prefix-scoped S3 credentials via `s3control get-data-access` (12h lifetime) before invoking the mirror script.

## Design

- **Immutable + mutable paths.** Each file lands at `s3://cellpainting-gallery/cpg0042-chandrasekaran-jump/source_all/workspace/publication_data/jump_rr/<record_id>/<file>/content` (immutable, tied to a specific Zenodo version) and `.../latest/<file>/content` (overwritten on each new release). `broad.io/*` short links can target `latest/` once and never need to be updated again. The trailing `/content` segment mirrors Zenodo's own download URL structure (`/api/records/<id>/files/<file>/content`); Datasette-Lite derives its table name from the URL's last path segment, so preserving `content` on both backends keeps the [JUMP_rr metadata JSONs](https://github.com/broadinstitute/monorepo/tree/main/libs/jump_rr/metadata) (which describe the table under `databases.data.tables.content`) valid against the CPG-served parquet without monorepo-side edits.
- **Edge cache.** A CloudFront distribution (`d3dw4c1b79pj57.cloudfront.net`) is provisioned via [`cellpainting-gallery-infra`](https://github.com/broadinstitute/cellpainting-gallery-infra)'s new `JumpRrCdnStack`, scoped strictly to the JUMP_rr origin path so the rest of CPG is unaffected. Its 1h cache TTL means daily-cron mirror updates to `latest/` propagate to the edge without explicit invalidation. The bucket stays public; the CDN is an additional, faster URL the broad.io short links target. This is phase 2 of the answer to #124's "loading is too slow" concern — phase 1 was the S3 mirror itself; if loading remains the complaint after the cutover, phase 3 would be a server-side Datasette deployment.
- **Streaming, no local disk.** `curl -fsSL <zenodo_url> | aws s3 cp - <s3_uri> --expected-size <bytes>`. The largest file in the JUMP_rr record (`compound_cosinesim_full.parquet`, ~49 GB) would not fit on a typical CI runner's disk.
- **Idempotency.** The Zenodo MD5 is stored as S3 user metadata `zenodo-md5`. On rerun, `head-object` checks the existing metadata; matching MD5 skips the upload. The `latest/` sync is always done (cheap server-side copy) so it self-heals if it ever drifts.
- **Version slug.** The Zenodo `version` field is null for this concept, so the script uses the Zenodo record ID as the immutable directory name. Each new version gets a new record ID.

## Deliberately not in this PR

- **Manifest layer in jump_hub.** Per Alán's pushback, dropped. With Zenodo as canonical and a stable `latest/` prefix on CPG, there is no second pointer to reconcile.
- **SNAPPY-flavored second copy for ggsql-wasm.** Dropped. ggsql-wasm has been used for ~a week and shouldn't drive a permanent two-flavor data layout. If hyparquet adds ZSTD support later, we revisit.
- **broad.io short-link cutover automation.** Each broad.io short link is a redirect to a Datasette-Lite URL whose `parquet=` query param currently points at a version-pinned Zenodo file. The cutover only swaps that param to the CPG `latest/` mirror; everything else (`metadata=`, `install=`) is unchanged. With `latest/` now populated and verified, the cutover is being executed by hand as part of closing out this PR — see the [cutover guide comment](https://github.com/broadinstitute/jump_hub/pull/125#issuecomment-4342879001) for the slug-by-slug `new_target` URLs. No code in this PR touches broad.io.

## Smoke test (already done locally)

```
ONLY_FILE=crispr_gallery.parquet ./tools/mirror_zenodo_to_cpg.sh   # uploaded
ONLY_FILE=crispr_gallery.parquet ./tools/mirror_zenodo_to_cpg.sh   # skipped per idempotency
```

Both `<record_id>/crispr_gallery.parquet` and `latest/crispr_gallery.parquet` are now on CPG with `zenodo-md5` and `zenodo-record-id` metadata. ETag matches Zenodo MD5 (`193abb229130302c5e73770ca937ff84`).

## Test plan

- [x] @afermg confirms the design matches the proposal in #124.
- [x] Run a full mirror once (manually via `workflow_dispatch` or locally) and verify all 18 files land on CPG.
- [x] Decide cron cadence and wire CPG credentials into repo secrets. Daily 06:00 UTC; static IAM keys via `cellpainting-gallery-infra` live in repo secrets, workflow mints temp Access Grants creds at runtime. Credential chain validated locally end-to-end (head/put/server-side copy/delete on a probe object). First scheduled cron run is the on-runner smoke test.
- [ ] Repoint the 9 JUMP_rr `broad.io/*` Datasette-Lite redirects to use the CPG `latest/` mirror as the `parquet=` source — slug-by-slug guide in [#125 (comment)](https://github.com/broadinstitute/jump_hub/pull/125#issuecomment-4342879001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)




